### PR TITLE
Upgrade to Java 17, Spring Boot 3.3.5, and modern dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,18 +7,17 @@ on:
 
 env:
    MAVEN_CLI_OPTS: >-
-     -Djava.version=${{ contains(github.event.head_commit.message, 'Code transformation completed') &&  '17' || '1.8' }}
+     -Djava.version=17
 
 jobs:
   q-code-transformation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: ${{ contains(github.event.head_commit.message, 'Code transformation completed') && '17' || '8' }}
-          
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'corretto'
 
       - name: Build and copy dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM maven:3.6.1-amazoncorretto-8 as build
+FROM maven:3.9.9-amazoncorretto-17 as build
 
-ENV MAVEN_VERSION 3.6.1
+ENV MAVEN_VERSION 3.9.9
 ENV MAVEN_HOME /usr/lib/mvn
 ENV PATH $MAVEN_HOME/bin:$PATH
 
@@ -12,7 +12,7 @@ COPY src src
 RUN mvn install -DskipTests
 RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*.jar)
 
-FROM maven:3.6.1-amazoncorretto-8
+FROM maven:3.9.9-amazoncorretto-17
 ARG DEPENDENCY=/workspace/app/target/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
       mavenCentral()
     }
     dependencies {
-        classpath('org.springframework.boot:spring-boot-gradle-plugin:2.3.0.RELEASE')
+        classpath('org.springframework.boot:spring-boot-gradle-plugin:3.3.5')
     }
 }
 
@@ -23,16 +23,19 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 17
+targetCompatibility = 17
 
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web") 
-    testCompile("org.springframework.boot:spring-boot-starter-test")
-    implementation platform('software.amazon.awssdk:bom:2.14.27')
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation platform('software.amazon.awssdk:bom:2.29.26')
     implementation 'software.amazon.awssdk:appconfig'
-    compile("org.json:json:20200518")
-    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    implementation("org.json:json:20240303")
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.3'
 }
 
+test {
+    useJUnitPlatform()
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>3.3.5</version>
     </parent>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.14.27</version>
+                <version>2.29.26</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -38,49 +38,60 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20200518</version>
+            <version>20240303</version>
         </dependency>
         <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-test</artifactId>
-        <scope>test</scope>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Maven -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.24.3</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>2.24.3</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/javax.persistence/javax.persistence-api -->
-        <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.1.0</version>
         </dependency>
 
     </dependencies>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <build>
@@ -92,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/src/main/java/com/amazonaws/samples/appconfig/movies/MoviesController.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/movies/MoviesController.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.appconfig.AppConfigClient;
 import software.amazon.awssdk.services.appconfig.model.GetConfigurationResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 

--- a/src/main/java/com/amazonaws/samples/appconfig/utils/Encoder.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/utils/Encoder.java
@@ -1,16 +1,17 @@
-// depreciation example - sun.misc.BASE64Encoder;
+// Migrated from deprecated internal BASE64Encoder to java.util.Base64
 package com.amazonaws.samples.appconfig.utils;
-import sun.misc.BASE64Encoder;
+import java.util.Base64;
 
 import java.util.Date;
 
 
 public class Encoder {
 
+    // Note: Date(int, int, int) constructor is deprecated but still compiles with a warning
     Date defaultDate = new Date(1999, 0, 1);
 
     byte[] bytes = new byte[57];
-    String enc1 = new sun.misc.BASE64Encoder().encode(bytes);
+    String enc1 = Base64.getEncoder().encodeToString(bytes);
 
 
 }

--- a/src/main/java/com/amazonaws/samples/appconfig/utils/Math.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/utils/Math.java
@@ -1,27 +1,28 @@
 //example from https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-to-java-17
 package com.amazonaws.samples.appconfig.utils;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class Math {
-    Boolean bool = new Boolean(true);
-    Byte b = new Byte("1");
-    Character c = new Character('c');
-    Double d = new Double(1.0);
-    Float f = new Float(1.1f);
-    Long l = new Long(1);
-    Short sh = new Short("12");
+    Boolean bool = Boolean.valueOf(true);
+    Byte b = Byte.valueOf("1");
+    Character c = Character.valueOf('c');
+    Double d = Double.valueOf(1.0);
+    Float f = Float.valueOf(1.1f);
+    Long l = Long.valueOf(1L);
+    Short sh = Short.valueOf("12");
     short s3 = 3;
-    Short sh3 = new Short(s3);
-    Integer i = new Integer(1);
+    Short sh3 = Short.valueOf(s3);
+    Integer i = Integer.valueOf(1);
 
     public void divide() {
         BigDecimal bd = BigDecimal.valueOf(10);
         BigDecimal bd2 = BigDecimal.valueOf(2);
-        bd.divide(bd2, BigDecimal.ROUND_DOWN);
-        bd.divide(bd2, 1);
-        bd.divide(bd2, 1, BigDecimal.ROUND_CEILING);
-        bd.divide(bd2, 1, 1);
-        bd.setScale(2, 1);
+        bd.divide(bd2, RoundingMode.DOWN);
+        bd.divide(bd2, RoundingMode.DOWN);
+        bd.divide(bd2, 1, RoundingMode.CEILING);
+        bd.divide(bd2, 1, RoundingMode.DOWN);
+        bd.setScale(2, RoundingMode.DOWN);
     }
 
    }

--- a/src/main/java/com/amazonaws/samples/appconfig/utils/Security.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/utils/Security.java
@@ -1,7 +1,12 @@
-//javax.security.cert to java.security.cert classes migration
+// Migrated from deprecated javax security cert to java.security.cert classes
 package com.amazonaws.samples.appconfig.utils;
 
-import javax.security.cert.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -13,7 +18,8 @@ public class Security {
         X509Certificate cert = null;
         try {
             InputStream inStream = new FileInputStream(certFile);
-            cert = X509Certificate.getInstance(inStream);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            cert = (X509Certificate) cf.generateCertificate(inStream);
         } catch (CertificateException e) {
             throw new RuntimeException(e);
         } catch (FileNotFoundException e) {

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MathTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MathTest.java
@@ -1,11 +1,12 @@
 package com.amazonaws.samples.appconfig.movies;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import com.amazonaws.samples.appconfig.utils.Math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MathTest {
 
@@ -18,21 +19,21 @@ public class MathTest {
         BigDecimal bd = BigDecimal.valueOf(10);
         BigDecimal bd2 = BigDecimal.valueOf(2);
         BigDecimal expectedResult1 = BigDecimal.valueOf(5);
-        assertEquals(expectedResult1, bd.divide(bd2, BigDecimal.ROUND_DOWN));
+        assertEquals(expectedResult1, bd.divide(bd2, RoundingMode.DOWN));
 
         // Test divide(BigDecimal, int)
         BigDecimal expectedResult2 = BigDecimal.valueOf(5.0);
 
         // Test divide(BigDecimal, int, int)
         BigDecimal expectedResult3 = BigDecimal.valueOf(5.0);
-        assertEquals(expectedResult3, bd.divide(bd2, 1, BigDecimal.ROUND_CEILING));
+        assertEquals(expectedResult3, bd.divide(bd2, 1, RoundingMode.CEILING));
 
         BigDecimal expectedResult4 = BigDecimal.valueOf(5.0);
-        assertEquals(expectedResult4, bd.divide(bd2, 1, 1));
+        assertEquals(expectedResult4, bd.divide(bd2, 1, RoundingMode.DOWN));
 
         // Test setScale(int, int)
         BigDecimal expectedResult5 = BigDecimal.valueOf(10);
-        bd.setScale(2, 1);
+        bd.setScale(2, RoundingMode.DOWN);
         assertEquals(expectedResult5, bd);
     }
 }

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MockTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MockTest.java
@@ -1,15 +1,15 @@
 package com.amazonaws.samples.appconfig.movies;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.mockito.Mockito;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
 

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MovieTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MovieTest.java
@@ -1,12 +1,9 @@
 package com.amazonaws.samples.appconfig.movies;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 import com.amazonaws.samples.appconfig.movies.MoviesController;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class MovieTest {
 

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MoviesControllerTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MoviesControllerTest.java
@@ -3,10 +3,12 @@ package com.amazonaws.samples.appconfig.movies;
 import com.amazonaws.samples.appconfig.utils.AppConfigUtility;
 import com.amazonaws.samples.appconfig.cache.ConfigurationCache;
 import com.amazonaws.samples.appconfig.model.ConfigurationKey;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 import software.amazon.awssdk.services.appconfig.AppConfigClient;
 import software.amazon.awssdk.services.appconfig.model.GetConfigurationResponse;
@@ -15,9 +17,10 @@ import java.time.Duration;
 import java.util.UUID;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 public class MoviesControllerTest {
 
     @Mock
@@ -31,9 +34,9 @@ public class MoviesControllerTest {
 
     private MoviesController moviesController;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         moviesController = new MoviesController();
         moviesController.env = env;
     }


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Full modernization upgrade of the project from Java 8 to Java 17 with updated dependencies across the entire stack.

### Build Configuration Changes
- **Java**: 1.8 → 17
- **Spring Boot**: 2.0.5 → 3.3.5
- **AWS SDK BOM**: 2.14.27 → 2.29.26
- **Log4j**: 2.13.3 → 2.24.3
- **JUnit**: 4.13.1 → Jupiter 5.11.3
- **Mockito**: 1.10.19 (mockito-all) → 5.14.2 (mockito-core + mockito-junit-jupiter)
- **Validation**: javax.validation 2.0.1 → jakarta.validation 3.1.0
- **org.json**: 20200518 → 20240303
- **Maven Compiler Plugin**: 3.8.1 → 3.13.0
- **Dockerfile**: amazoncorretto-8 → amazoncorretto-17, Maven 3.6.1 → 3.9.9
- **build.gradle**: Modern configurations (`implementation`/`testImplementation`), `useJUnitPlatform()`
- **CI workflow**: Updated to actions v4, Java 17, Corretto distribution

### Source Code Modernization
- `javax.validation.Valid` → `jakarta.validation.Valid`
- `javax.security.cert.*` → `java.security.cert.*`
- `sun.misc.BASE64Encoder` → `java.util.Base64`
- Deprecated wrapper constructors → `valueOf()` factory methods
- `BigDecimal.ROUND_*` constants → `RoundingMode` enum

### Test Migration
- JUnit 4 → JUnit 5 (Jupiter) annotations and assertions
- Mockito 1.x → Mockito 5.x APIs (`ArgumentMatchers`, `openMocks`, `@ExtendWith`)
- Removed `@RunWith(SpringRunner.class)` (unnecessary with JUnit 5)

### Testing
- Build/test execution was not possible in this environment (no network access for dependency downloads). The changes follow standard migration patterns and should be verified by running `mvn clean verify` locally.